### PR TITLE
Feat/login

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,15 @@
+### PR 종류
+
+-  [ ] 🐞 Bugfix
+-  [ ] ✨ New Feature
+-  [ ] 📚 Documentation
+-  [ ] ♻️ Refactoring
+-  [ ] 🧪 Other
+
+### 핵심 내용
+
+-
+
+### 부가 설명
+
+-

--- a/src/features/user/userSlice.js
+++ b/src/features/user/userSlice.js
@@ -1,49 +1,65 @@
-import { createSlice, createAsyncThunk } from "@reduxjs/toolkit";
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 
-import { showToastMessage } from "../common/uiSlice";
-import api from "../../utils/api";
-import { initialCart } from "../cart/cartSlice";
+import { showToastMessage } from '../common/uiSlice';
+import api from '../../utils/api';
+import { initialCart } from '../cart/cartSlice';
 
 export const loginWithEmail = createAsyncThunk(
-  "user/loginWithEmail",
-  async ({ email, password }, { rejectWithValue }) => {}
+   'user/loginWithEmail',
+   async ({ email, password }, { rejectWithValue }) => {},
 );
 
 export const loginWithGoogle = createAsyncThunk(
-  "user/loginWithGoogle",
-  async (token, { rejectWithValue }) => {}
+   'user/loginWithGoogle',
+   async (token, { rejectWithValue }) => {},
 );
 
 export const logout = () => (dispatch) => {};
 export const registerUser = createAsyncThunk(
-  "user/registerUser",
-  async (
-    { email, name, password, navigate },
-    { dispatch, rejectWithValue }
-  ) => {}
+   'user/registerUser',
+   async ({ email, name, password, navigate }, { dispatch, rejectWithValue }) => {
+      try {
+         const response = await api.post('/user/regist', { email, name, password });
+         dispatch(showToastMessage({ message: '회원 가입이 완료되었습니다.', status: 'success' }));
+         navigate('/login');
+         return response.data.data;
+      } catch (error) {
+         dispatch(showToastMessage({ message: '회원 가입 중 오류가 발생했습니다..', status: 'error' }));
+         return rejectWithValue(error.error);
+      }
+   },
 );
 
-export const loginWithToken = createAsyncThunk(
-  "user/loginWithToken",
-  async (_, { rejectWithValue }) => {}
-);
+export const loginWithToken = createAsyncThunk('user/loginWithToken', async (_, { rejectWithValue }) => {});
 
 const userSlice = createSlice({
-  name: "user",
-  initialState: {
-    user: null,
-    loading: false,
-    loginError: null,
-    registrationError: null,
-    success: false,
-  },
-  reducers: {
-    clearErrors: (state) => {
-      state.loginError = null;
-      state.registrationError = null;
-    },
-  },
-  extraReducers: (builder) => {},
+   name: 'user',
+   initialState: {
+      user: null,
+      loading: false,
+      loginError: null,
+      registrationError: null,
+      success: false,
+   },
+   reducers: {
+      clearErrors: (state) => {
+         state.loginError = null;
+         state.registrationError = null;
+      },
+   },
+   extraReducers: (builder) => {
+      builder
+         .addCase(registerUser.pending, (state) => {
+            state.loading = true;
+         })
+         .addCase(registerUser.fulfilled, (state) => {
+            state.loading = false;
+            state.registrationError = null;
+         })
+         .addCase(registerUser.rejected, (state, action) => {
+            state.registrationError = action.payload;
+         });
+   },
 });
 export const { clearErrors } = userSlice.actions;
 export default userSlice.reducer;


### PR DESCRIPTION
### PR 종류

-  [ ] 🐞 Bugfix
-  [x] ✨ New Feature
-  [ ] 📚 Documentation
-  [ ] ♻️ Refactoring
-  [ ] 🧪 Other

### 핵심 내용

- 비동기 액션에 API 통신 및 Toast 메시지 기능 추가
- showToastMessage 액션을 통해 회원가입 성공 및 실패 시 사용자 알림 표시
   ![image](https://github.com/user-attachments/assets/7acc1f18-706d-42c2-bb3e-3a7b5cbef0a5)
- extraReducers를 사용하여 비동기 액션의 pending, fulfilled, rejected 상태에 따른 UI 상태 관리


- 회원 가입 데이터가 DB에 저장
  ![image](https://github.com/user-attachments/assets/4595e6bd-6a89-496d-987b-13617be25af8)
