### PR TITLE
feat/product - 상품 목록 페이지네이션 기능 구현

### DIFF
--- a/src/features/product/productSlice.js
+++ b/src/features/product/productSlice.js
@@ -7,8 +7,9 @@ export const getProductList = createAsyncThunk(
    async (query, { rejectWithValue }) => {
       try {
          const response = await api.get('product', { params: { ...query } });
+         console.log(response);
          if (response.status !== 200) throw new Error(response.error);
-         return response.data.productList;
+         return response.data;
       } catch (error) {
          return rejectWithValue(error.error);
       }
@@ -27,6 +28,7 @@ export const createProduct = createAsyncThunk(
          const response = await api.post('product/regist', formData);
          if (response.status !== 200) throw new Error(response.error);
          dispatch(showToastMessage({ message: '상품 등록이 완료되었습니다.', status: 'success' }));
+         dispatch(getProductList({ page: 1 }));
          return response.data.data;
       } catch (error) {
          dispatch(showToastMessage({ message: '상품 등록이 실패했습니다.', status: 'error' }));
@@ -88,8 +90,9 @@ const productSlice = createSlice({
          })
          .addCase(getProductList.fulfilled, (state, action) => {
             state.loading = false;
-            state.productList = action.payload;
+            state.productList = action.payload.productList;
             state.error = '';
+            state.totalPageNum = action.payload.totalPageNum;
          })
          .addCase(getProductList.rejected, (state, action) => {
             state.loading = false;

--- a/src/page/AdminProductPage/AdminProductPage.js
+++ b/src/page/AdminProductPage/AdminProductPage.js
@@ -51,7 +51,7 @@ const AdminProductPage = () => {
    };
 
    const handlePageClick = ({ selected }) => {
-      //  쿼리에 페이지값 바꿔주기
+      setSearchQuery({ ...searchQuery, page: selected + 1 });
    };
 
    return (
@@ -79,7 +79,7 @@ const AdminProductPage = () => {
                nextLabel='next >'
                onPageChange={handlePageClick}
                pageRangeDisplayed={5}
-               pageCount={100}
+               pageCount={totalPageNum}
                forcePage={searchQuery.page - 1}
                previousLabel='< previous'
                renderOnZeroPageCount={null}


### PR DESCRIPTION
### PR 종류

-  [ ] 🐞 Bugfix
-  [x] ✨ New Feature
-  [ ] 📚 Documentation
-  [ ] ♻️ Refactoring
-  [ ] 🧪 Other

### 핵심 내용

- 상품 목록 조회 시, `ReactPaginate`를 활용하여 페이지네이션 기능을 적용
- 현재 URL의 쿼리스트링을 활용하여 페이지 정보를 유지하도록 구현
  - 전체 상품 목록(getProductList) 요청 시, 현재 `page` 및 `name` 파라미터를 포함하여 서버에서 데이터를 가져오도록 변경.
  - `searchQuery` 상태를 `useSearchParams`와 연동하여 URL 기반으로 검색 및 페이징 가능하게 수정.
  - 하단의 페이지 넘버(handlePageClick) 함수 추가하여 사용자가 페이지를 변경하면 `searchQuery` 상태를 업데이트하고, 자동으로 상품 목록을 다시 불러오도록 처리.
  - `navigate('?' + query)` 사용하여 현재 경로를 유지하면서 쿼리스트링만 변경하는 방식 적용.