### PR TITLE
feat/product - 관리자 페이지 - 상품 수정 기능 추가

### DIFF
--- a/src/features/product/productSlice.js
+++ b/src/features/product/productSlice.js
@@ -44,7 +44,18 @@ export const deleteProduct = createAsyncThunk(
 
 export const editProduct = createAsyncThunk(
    'products/editProduct',
-   async ({ id, ...formData }, { dispatch, rejectWithValue }) => {},
+   async ({ id, ...formData }, { dispatch, rejectWithValue }) => {
+      try {
+         const response = await api.put(`/product/${id}`, formData);
+         if (response.status !== 200) throw new Error(response.error);
+         dispatch(getProductList({ page: 1 }));
+         dispatch(showToastMessage({ message: '상품 수정이 완료되었습니다.', status: 'success' }));
+         return response.data.data;
+      } catch (error) {
+         dispatch(showToastMessage({ message: '상품 수정이 실패했습니다.', status: 'error' }));
+         return rejectWithValue(error.error);
+      }
+   },
 );
 
 // 슬라이스 생성
@@ -76,9 +87,12 @@ const productSlice = createSlice({
             state.loading = true;
          })
          .addCase(createProduct.fulfilled, (state) => {
-            state.loading = false;
             state.error = '';
             state.success = true;
+            state.loading = false;
+            setTimeout(() => {
+               state.success = true;
+            }, 1000);
          })
          .addCase(createProduct.rejected, (state, action) => {
             state.loading = false;
@@ -94,9 +108,21 @@ const productSlice = createSlice({
             state.error = '';
             state.totalPageNum = action.payload.totalPageNum;
          })
-         .addCase(getProductList.rejected, (state, action) => {
+         .addCase(editProduct.pending, (state, action) => {
+            state.loading = true;
+         })
+         .addCase(editProduct.fulfilled, (state) => {
+            state.error = '';
+            state.success = true;
+            state.loading = false;
+            setTimeout(() => {
+               state.success = false;
+            }, 1000);
+         })
+         .addCase(editProduct.rejected, (state, action) => {
             state.loading = false;
             state.error = action.payload;
+            state.success = false;
          });
    },
 });

--- a/src/page/AdminProductPage/AdminProductPage.js
+++ b/src/page/AdminProductPage/AdminProductPage.js
@@ -13,6 +13,7 @@ const AdminProductPage = () => {
    const [query] = useSearchParams();
    const dispatch = useDispatch();
    const productList = useSelector((state) => state.product.productList) || [];
+   const success = useSelector((state) => state.product.success);
    const [showDialog, setShowDialog] = useState(false);
    const [searchQuery, setSearchQuery] = useState({
       page: query.get('page') || 1,
@@ -36,13 +37,20 @@ const AdminProductPage = () => {
       navigate('?' + query);
    }, [searchQuery]);
 
+   useEffect(() => {
+      if (success) {
+         setShowDialog(false);
+      }
+   }, [success]);
+
    const deleteItem = (id) => {
       //아이템 삭제하가ㅣ
    };
 
    const openEditForm = (product) => {
-      //edit모드로 설정하고
-      // 아이템 수정다이얼로그 열어주기
+      setMode('edit');
+      dispatch(setSelectedProduct(product));
+      setShowDialog(true);
    };
 
    const handleClickNewItem = () => {

--- a/src/page/AdminProductPage/component/NewItemDialog.js
+++ b/src/page/AdminProductPage/component/NewItemDialog.js
@@ -28,6 +28,12 @@ const NewItemDialog = ({ mode, showDialog, setShowDialog }) => {
    }, [success]);
 
    useEffect(() => {
+      if (error) {
+         console.error('상품 업데이트 오류:', error);
+      }
+   }, [error]);
+
+   useEffect(() => {
       if (error || !success) {
          dispatch(clearError());
       }
@@ -55,16 +61,15 @@ const NewItemDialog = ({ mode, showDialog, setShowDialog }) => {
    };
 
    const handleSubmit = (event) => {
-      console.log('formData : ', formData);
       event.preventDefault();
       if (stock.length === 0) return setStockError(true);
       const totalStock = stock.reduce((total, item) => {
          return { ...total, [item[0]]: parseInt(item[1]) };
       }, {});
       if (mode === 'new') {
-         dispatch(createProduct({ ...formData, totalStock }));
+         dispatch(createProduct({ ...formData, stock: totalStock }));
       } else {
-         // 상품 수정하기
+         dispatch(editProduct({ ...formData, stock: totalStock, id: selectedProduct._id }));
       }
    };
 


### PR DESCRIPTION
### PR 종류

-  [ ] 🐞 Bugfix
-  [x] ✨ New Feature
-  [ ] 📚 Documentation
-  [ ] ♻️ Refactoring
-  [ ] 🧪 Other

### 핵심 내용

- 상품 수정 기능 추가 (editProduct 액션 및 리듀서 구현)
- 상품 수정 모달(NewItemDialog)에서 기존 데이터를 불러와 수정 가능하도록 구현
- 수정된 데이터를 서버에 전송하여 업데이트 처리

### 부가 설명

- `editProduct` 액션을 생성하여 `PUT` `/product/:id API` 호출
- NewItemDialog에서 mode === 'edit'일 경우 기존 데이터를 폼에 표시
- 성공적으로 수정되면 `setShowDialog`의 State를 false로 설정하여 모달 창을 닫음
