### PR TITLE
feat/product - 관리자/사용자 페이지에서 조회되는 상품 분리

### DIFF
--- a/src/constants/product.constants.js
+++ b/src/constants/product.constants.js
@@ -29,7 +29,12 @@ export const REVERSE_CATEGORY_MAP = Object.fromEntries(
    Object.entries(CATEGORY_MAP).map(([kor, eng]) => [eng, kor]),
 );
 
-export const STATUS = ['active', 'disactive'];
+// export const STATUS = ['active', 'disactive'];
+export const STATUS_MAP = { 게시: 'active', 숨김: 'disactive' };
+export const REVERSE_STATUS_MAP = Object.fromEntries(
+   Object.entries(STATUS_MAP).map(([kor, eng]) => [eng, kor]),
+);
+
 export const SIZE = ['XS', 'S', 'M', 'L', 'XL', 'XXL'];
 export const TOGGLE_ITEM_DIALOG = 'TOGGLE_ITEM_DIALOG';
 export const SEARCH_PRODUCT_REQUEST = ' SEARCH_PRODUCT_REQUEST';

--- a/src/features/product/productSlice.js
+++ b/src/features/product/productSlice.js
@@ -2,11 +2,24 @@ import { createSlice, createAsyncThunk } from '@reduxjs/toolkit';
 import api from '../../utils/api';
 import { showToastMessage } from '../common/uiSlice';
 
-export const getProductList = createAsyncThunk(
-   'products/getProductList',
+export const getUserProductList = createAsyncThunk(
+   'products/getUserProductList',
    async (query, { rejectWithValue }) => {
       try {
          const response = await api.get('/product', { params: { ...query } });
+         return response.data;
+      } catch (error) {
+         console.error(error.message);
+         return rejectWithValue(error.error);
+      }
+   },
+);
+
+export const getAdminProductList = createAsyncThunk(
+   'products/getAdminProductList',
+   async (query, { rejectWithValue }) => {
+      try {
+         const response = await api.get('/product/admin', { params: { ...query } });
          return response.data;
       } catch (error) {
          console.error(error.message);
@@ -48,7 +61,7 @@ export const createProduct = createAsyncThunk(
       try {
          const response = await api.post('/product/regist', formData);
          dispatch(showToastMessage({ message: '상품 등록이 완료되었습니다.', status: 'success' }));
-         dispatch(getProductList({ page: 1 }));
+         dispatch(getUserProductList({ page: 1 }));
          return response.data.data;
       } catch (error) {
          console.error(error.message);
@@ -64,7 +77,7 @@ export const deleteProduct = createAsyncThunk(
       try {
          const response = await api.delete(`/product/${id}`);
          dispatch(showToastMessage({ message: '상품 삭제 완료', status: 'success' }));
-         dispatch(getProductList({ page: 1 }));
+         dispatch(getUserProductList({ page: 1 }));
          return response.data;
       } catch (error) {
          console.error(error.message);
@@ -78,7 +91,7 @@ export const editProduct = createAsyncThunk(
    async ({ id, ...formData }, { dispatch, rejectWithValue }) => {
       try {
          const response = await api.put(`/product/${id}`, formData);
-         dispatch(getProductList({ page: 1 }));
+         dispatch(getUserProductList({ page: 1 }));
          dispatch(showToastMessage({ message: '상품 수정이 완료되었습니다.', status: 'success' }));
          return response.data.data;
       } catch (error) {
@@ -138,14 +151,31 @@ const productSlice = createSlice({
             state.loading = false;
             state.error = action.payload;
          })
-         .addCase(getProductList.pending, (state) => {
+         .addCase(getUserProductList.pending, (state) => {
             state.loading = true;
          })
-         .addCase(getProductList.fulfilled, (state, action) => {
+         .addCase(getUserProductList.fulfilled, (state, action) => {
             state.loading = false;
-            state.productList = action.payload.productList;
+            state.userProductList = action.payload.productList;
             state.error = '';
             state.totalPageNum = action.payload.totalPageNum;
+         })
+         .addCase(getUserProductList.rejected, (state, action) => {
+            state.loading = false;
+            state.error = action.payload;
+         })
+         .addCase(getAdminProductList.pending, (state) => {
+            state.loading = true;
+         })
+         .addCase(getAdminProductList.fulfilled, (state, action) => {
+            state.loading = false;
+            state.adminProductList = action.payload.productList;
+            state.error = '';
+            state.totalPageNum = action.payload.totalPageNum;
+         })
+         .addCase(getAdminProductList.rejected, (state, action) => {
+            state.loading = false;
+            state.error = action.payload;
          })
          .addCase(editProduct.pending, (state, action) => {
             state.loading = true;

--- a/src/page/AdminProductPage/AdminProductPage.js
+++ b/src/page/AdminProductPage/AdminProductPage.js
@@ -6,13 +6,13 @@ import ReactPaginate from 'react-paginate';
 import SearchBox from '../../common/component/SearchBox';
 import NewItemDialog from './component/NewItemDialog';
 import ProductTable from './component/ProductTable';
-import { getProductList, deleteProduct, setSelectedProduct } from '../../features/product/productSlice';
+import { deleteProduct, setSelectedProduct, getAdminProductList } from '../../features/product/productSlice';
 
 const AdminProductPage = () => {
    const navigate = useNavigate();
    const [query] = useSearchParams();
    const dispatch = useDispatch();
-   const productList = useSelector((state) => state.product.productList) || [];
+   const productList = useSelector((state) => state.product.adminProductList) || [];
    const success = useSelector((state) => state.product.success);
    const [showDialog, setShowDialog] = useState(false);
    const [searchQuery, setSearchQuery] = useState({
@@ -34,7 +34,7 @@ const AdminProductPage = () => {
    ];
 
    useEffect(() => {
-      dispatch(getProductList({ ...searchQuery }));
+      dispatch(getAdminProductList({ ...searchQuery }));
    }, [query, dispatch, searchQuery]);
 
    useEffect(() => {

--- a/src/page/AdminProductPage/component/NewItemDialog.js
+++ b/src/page/AdminProductPage/component/NewItemDialog.js
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Form, Modal, Button, Row, Col, Alert } from 'react-bootstrap';
 import { useDispatch, useSelector } from 'react-redux';
 import CloudinaryUploadWidget from '../../../utils/CloudinaryUploadWidget';
-import { CATEGORY, STATUS, SIZE, CATEGORY_MAP } from '../../../constants/product.constants';
+import { SIZE, CATEGORY_MAP, STATUS_MAP } from '../../../constants/product.constants';
 import '../style/adminProduct.style.css';
 import { clearError, createProduct, editProduct } from '../../../features/product/productSlice';
 
@@ -26,7 +26,7 @@ const NewItemDialog = ({ mode, showDialog, setShowDialog }) => {
 
    useEffect(() => {
       if (success) setShowDialog(false);
-   }, [success]);
+   }, [success, setShowDialog]);
 
    useEffect(() => {
       if (error) {
@@ -41,7 +41,7 @@ const NewItemDialog = ({ mode, showDialog, setShowDialog }) => {
       if (showDialog) {
          if (mode === 'edit') {
             setFormData(selectedProduct);
-            // 객체형태로 온 stock을  다시 배열로 세팅해주기
+            // 객체형태로 온 stock =>  다시 배열로
             const sizeArray = Object.keys(selectedProduct.stock).map((size) => [
                size,
                selectedProduct.stock[size],
@@ -52,7 +52,7 @@ const NewItemDialog = ({ mode, showDialog, setShowDialog }) => {
             setStock([]);
          }
       }
-   }, [showDialog]);
+   }, [showDialog, dispatch, error, mode, selectedProduct, success]);
 
    const handleClose = () => {
       setShowDialog(false);
@@ -70,9 +70,17 @@ const NewItemDialog = ({ mode, showDialog, setShowDialog }) => {
       }, {});
 
       const categoryEnglish = formData.category.map((cat) => CATEGORY_MAP[cat] || cat);
+      const statusEnglish = STATUS_MAP[formData.status] || formData.status;
 
       if (mode === 'new') {
-         dispatch(createProduct({ ...formData, category: categoryEnglish, stock: totalStock }));
+         dispatch(
+            createProduct({
+               ...formData,
+               category: categoryEnglish,
+               stock: totalStock,
+               status: statusEnglish,
+            }),
+         );
       } else {
          dispatch(
             editProduct({
@@ -275,9 +283,9 @@ const NewItemDialog = ({ mode, showDialog, setShowDialog }) => {
                <Form.Group as={Col} controlId='status'>
                   <Form.Label>상품 상태(게시, 숨김)</Form.Label>
                   <Form.Select value={formData.status} onChange={handleChange} required>
-                     {STATUS.map((item, idx) => (
-                        <option key={idx} value={item.toLowerCase()}>
-                           {item}
+                     {Object.keys(STATUS_MAP).map((kor, idx) => (
+                        <option key={idx} value={STATUS_MAP[kor]}>
+                           {kor}
                         </option>
                      ))}
                   </Form.Select>

--- a/src/page/LandingPage/LandingPage.js
+++ b/src/page/LandingPage/LandingPage.js
@@ -3,17 +3,17 @@ import ProductCard from './components/ProductCard';
 import { Row, Col, Container } from 'react-bootstrap';
 import { useSearchParams } from 'react-router-dom';
 import { useDispatch, useSelector } from 'react-redux';
-import { getProductList } from '../../features/product/productSlice';
+import { getUserProductList } from '../../features/product/productSlice';
 
 const LandingPage = () => {
    const dispatch = useDispatch();
 
-   const productList = useSelector((state) => state.product.productList);
+   const productList = useSelector((state) => state.product.userProductList);
    const [query] = useSearchParams();
    const name = query.get('name');
    useEffect(() => {
       dispatch(
-         getProductList({
+         getUserProductList({
             name,
          }),
       );


### PR DESCRIPTION
### PR 종류

-  [ ] 🐞 Bugfix
-  [x] ✨ New Feature
-  [ ] 📚 Documentation
-  [ ] ♻️ Refactoring
-  [ ] 🧪 Other

### 핵심 내용

- 관리자 페이지와 사용자 페이지의 상품 조회 로직 분리

#### 사용자 페이지 (LandingPage.js)
- `/products` API 호출 → `status: "active"`인 상품만 조회
- Redux 액션: `getUserProductList` 사용

#### 관리자 페이지 (AdminProductPage.js)
- `/admin/products` API 호출 → 모든 상품(숨김/삭제 포함) 조회
- Redux 액션: `getAdminProductList` 사용

#### Redux Slice (`productSlice.js`) 수정

- 기존 `getProductList`액션을 `getUserProductList`, `getAdminProductList`액션으로 분리
