### PR TITLE
feat/product - 상품 통계 조회 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.2.2",
         "bootstrap": "^5.1.3",
+        "d3": "^7.9.0",
         "dotenv": "^16.4.7",
         "react": "^17.0.2",
         "react-bootstrap": "^2.1.1",
@@ -6209,6 +6210,387 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
       "integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
     },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.0.tgz",
+      "integrity": "sha512-YyUI6AEuY/Wpt8KWLgZHsIU86atmikuoOmCfommt0LYHiQSPjvX2AcFc38PX0CBpr2RCyZhjex+NS/LPOv6YqA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
@@ -6365,6 +6747,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/delayed-stream": {
@@ -8905,6 +9295,14 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/invariant": {
@@ -14507,6 +14905,11 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg=="
+    },
     "node_modules/rollup": {
       "version": "2.66.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.66.1.tgz",
@@ -14597,6 +15000,11 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ=="
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.2.2",
     "bootstrap": "^5.1.3",
+    "d3": "^7.9.0",
     "dotenv": "^16.4.7",
     "react": "^17.0.2",
     "react-bootstrap": "^2.1.1",

--- a/src/common/component/Sidebar.js
+++ b/src/common/component/Sidebar.js
@@ -25,6 +25,9 @@ const Sidebar = () => {
                <li className='sidebar-item' onClick={() => handleSelectMenu('/admin/order?page=1')}>
                   주문 관리
                </li>
+               <li className='sidebar-item' onClick={() => handleSelectMenu('/admin/product/stats')}>
+                  상품 통계
+               </li>
             </ul>
          </div>
       );

--- a/src/features/product/productSlice.js
+++ b/src/features/product/productSlice.js
@@ -94,12 +94,27 @@ export const editProduct = createAsyncThunk(
    },
 );
 
+export const getAdminProductListForStats = createAsyncThunk(
+   'products/getAdminProductListForStats',
+   async (_, { rejectWithValue }) => {
+      try {
+         const response = await api.get('/product/admin/stats');
+         console.log(response);
+         return response.data.data;
+      } catch (error) {
+         console.error(error.message);
+         return rejectWithValue(error.error);
+      }
+   },
+);
+
 // 슬라이스 생성
 const productSlice = createSlice({
    name: 'products',
    initialState: {
       userProductList: [],
       productList: [],
+      productListForStats: [],
       selectedProduct: null,
       loading: false,
       error: '',
@@ -192,6 +207,18 @@ const productSlice = createSlice({
             state.error = '';
          })
          .addCase(getProductDetail.rejected, (state, action) => {
+            state.loading = false;
+            state.error = action.payload;
+         })
+         .addCase(getAdminProductListForStats.pending, (state) => {
+            state.loading = true;
+         })
+         .addCase(getAdminProductListForStats.fulfilled, (state, action) => {
+            state.loading = false;
+            state.productListForStats = action.payload;
+            state.error = '';
+         })
+         .addCase(getAdminProductListForStats.rejected, (state, action) => {
             state.loading = false;
             state.error = action.payload;
          });

--- a/src/page/AdminProductPage/AdminProductStatsPage.js
+++ b/src/page/AdminProductPage/AdminProductStatsPage.js
@@ -1,0 +1,410 @@
+import React, { useEffect, useRef } from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import { getAdminProductListForStats } from '../../features/product/productSlice';
+import * as d3 from 'd3';
+import Spinner from '../../common/component/Spinner';
+import './style/adminProduct.style.css'; //  CSS 파일 추가
+
+const AdminProductStats = () => {
+   const dispatch = useDispatch();
+   const { loading, productListForStats = [] } = useSelector((state) => state.product);
+
+   const barChartRef = useRef(null);
+   const histogramRef = useRef(null);
+   const stackedBarChartRef = useRef(null);
+   const pieChartRef = useRef(null);
+
+   useEffect(() => {
+      dispatch(getAdminProductListForStats());
+   }, [dispatch]);
+
+   useEffect(() => {
+      if (productListForStats.length > 0) {
+         drawBarChart();
+         drawHistogram();
+         drawStackedBarChart();
+         drawPieChart();
+      }
+   }, [productListForStats]);
+
+   //  카테고리별 상품 개수 (막대 그래프)
+   const drawBarChart = () => {
+      const categoryCount = {};
+      productListForStats.forEach((product) => {
+         product.category.forEach((cat) => {
+            categoryCount[cat] = (categoryCount[cat] || 0) + 1;
+         });
+      });
+
+      const data = Object.entries(categoryCount).map(([name, count]) => ({ name, count }));
+
+      d3.select(barChartRef.current).selectAll('*').remove();
+
+      const width = barChartRef.current.clientWidth;
+      const height = barChartRef.current.clientHeight;
+
+      const margin = { top: 50, right: 30, bottom: 80, left: 50 };
+      const innerWidth = width - margin.left - margin.right;
+      const innerHeight = height - margin.top - margin.bottom;
+
+      const svg = d3.select(barChartRef.current).append('svg').attr('width', width).attr('height', height);
+
+      svg.append('text')
+         .attr('x', width / 2)
+         .attr('y', 20)
+         .attr('text-anchor', 'middle')
+         .attr('class', 'chart-title')
+         .text('카테고리별 상품 개수')
+         .style('font-size', '22px');
+
+      const x = d3
+         .scaleBand()
+         .domain(data.map((d) => d.name))
+         .range([0, innerWidth])
+         .padding(0.2);
+
+      const y = d3
+         .scaleLinear()
+         .domain([0, d3.max(data, (d) => d.count)])
+         .range([innerHeight, 0]);
+
+      const g = svg.append('g').attr('transform', `translate(${margin.left}, ${margin.top})`);
+
+      const tooltip = d3
+         .select('body')
+         .append('div')
+         .style('position', 'absolute')
+         .style('visibility', 'hidden')
+         .style('background', 'white')
+         .style('border', '1px solid black')
+         .style('padding', '5px')
+         .style('border-radius', '5px')
+         .style('font-size', '26px')
+         .style('pointer-events', 'none');
+
+      g.selectAll('rect')
+         .data(data)
+         .enter()
+         .append('rect')
+         .attr('x', (d) => x(d.name))
+         .attr('y', (d) => y(d.count))
+         .attr('width', x.bandwidth())
+         .attr('height', (d) => innerHeight - y(d.count))
+         .attr('fill', 'steelblue')
+         .on('mouseover', (event, d) => {
+            tooltip
+               .style('visibility', 'visible')
+               .text(`카테고리: ${d.name}, 상품 개수: ${d.count}`)
+               .style('left', `${event.pageX + 10}px`)
+               .style('top', `${event.pageY - 20}px`);
+         })
+         .on('mousemove', (event) => {
+            tooltip.style('left', `${event.pageX + 10}px`).style('top', `${event.pageY - 20}px`);
+         })
+         .on('mouseout', () => {
+            tooltip.style('visibility', 'hidden');
+         });
+
+      g.append('g')
+         .attr('transform', `translate(0, ${innerHeight})`)
+         .call(d3.axisBottom(x).tickSize(5).tickPadding(10))
+         .selectAll('text')
+         .attr('transform', 'rotate(-20)')
+         .style('text-anchor', 'end')
+         .style('font-size', '20px');
+
+      g.append('g').call(d3.axisLeft(y)).style('font-size', '20px');
+   };
+
+   // 상품 가격 분포
+   const drawHistogram = () => {
+      const prices = productListForStats.map((p) => p.price);
+      const min = d3.min(prices);
+      const max = d3.max(prices);
+      const bins = d3.histogram().domain([min, max]).thresholds(10)(prices);
+
+      d3.select(histogramRef.current).selectAll('*').remove();
+
+      const width = histogramRef.current.clientWidth;
+      const height = histogramRef.current.clientHeight;
+
+      const margin = { top: 50, right: 30, bottom: 80, left: 50 };
+      const innerWidth = width - margin.left - margin.right;
+      const innerHeight = height - margin.top - margin.bottom;
+
+      const svg = d3.select(histogramRef.current).append('svg').attr('width', width).attr('height', height);
+
+      svg.append('text')
+         .attr('x', width / 2)
+         .attr('y', 20)
+         .attr('text-anchor', 'middle')
+         .attr('class', 'chart-title')
+         .text('상품 가격 분포')
+         .style('font-size', '22px');
+
+      const x = d3
+         .scaleBand()
+         .domain(bins.map((d) => `${Math.round(d.x0)}-${Math.round(d.x1)}`))
+         .range([0, innerWidth])
+         .padding(0.2);
+
+      const y = d3
+         .scaleLinear()
+         .domain([0, d3.max(bins, (d) => d.length)])
+         .range([innerHeight, 0]);
+
+      const g = svg.append('g').attr('transform', `translate(${margin.left}, ${margin.top})`);
+
+      const tooltip = d3
+         .select('body')
+         .append('div')
+         .style('position', 'absolute')
+         .style('visibility', 'hidden')
+         .style('background', 'rgba(0, 0, 0, 0.8)')
+         .style('color', 'white')
+         .style('padding', '8px')
+         .style('border-radius', '5px')
+         .style('font-size', '26px')
+         .style('pointer-events', 'none');
+
+      g.selectAll('rect')
+         .data(bins)
+         .enter()
+         .append('rect')
+         .attr('x', (d) => x(`${Math.round(d.x0)}-${Math.round(d.x1)}`))
+         .attr('y', (d) => y(d.length))
+         .attr('width', x.bandwidth())
+         .attr('height', (d) => innerHeight - y(d.length))
+         .attr('fill', 'orange')
+         .on('mouseover', (event, d) => {
+            tooltip
+               .style('visibility', 'visible')
+               .text(`가격 범위: ${Math.round(d.x0)} - ${Math.round(d.x1)}, 상품 수: ${d.length}`)
+               .style('left', `${event.pageX + 10}px`)
+               .style('top', `${event.pageY - 20}px`);
+         })
+         .on('mousemove', (event) => {
+            tooltip.style('left', `${event.pageX + 10}px`).style('top', `${event.pageY - 20}px`);
+         })
+         .on('mouseout', () => {
+            tooltip.style('visibility', 'hidden');
+         });
+
+      g.append('g')
+         .attr('transform', `translate(0, ${innerHeight})`)
+         .call(d3.axisBottom(x).tickSize(5).tickPadding(10))
+         .selectAll('text')
+         .attr('transform', 'rotate(-20)')
+         .style('text-anchor', 'end')
+         .style('font-size', '20px');
+
+      g.append('g').call(d3.axisLeft(y)).style('font-size', '20px');
+   };
+
+   // 카테고리 별 사이즈 별 재고
+   const drawStackedBarChart = () => {
+      const categoryStock = {};
+      productListForStats.forEach((product) => {
+         const category = product.category[0];
+         if (!categoryStock[category]) {
+            categoryStock[category] = { name: category, M: 0, L: 0, XL: 0, XXL: 0 };
+         }
+         Object.entries(product.stock || {}).forEach(([size, quantity]) => {
+            categoryStock[category][size.toUpperCase()] += quantity;
+         });
+      });
+
+      const data = Object.values(categoryStock);
+      const keys = ['M', 'L', 'XL', 'XXL'];
+      const colors = { M: '#ff7300', L: '#387908', XL: '#8884d8', XXL: '#82ca9d' };
+
+      d3.select(stackedBarChartRef.current).selectAll('*').remove();
+
+      const width = stackedBarChartRef.current.clientWidth;
+      const height = stackedBarChartRef.current.clientHeight;
+
+      const margin = { top: 50, right: 150, bottom: 80, left: 70 };
+      const innerWidth = width - margin.left - margin.right;
+      const innerHeight = height - margin.top - margin.bottom;
+
+      const svg = d3
+         .select(stackedBarChartRef.current)
+         .append('svg')
+         .attr('width', width)
+         .attr('height', height);
+
+      svg.append('text')
+         .attr('x', width / 2)
+         .attr('y', 20)
+         .attr('text-anchor', 'middle')
+         .attr('class', 'chart-title')
+         .style('font-size', '22px')
+         .text('카테고리별 사이즈별 재고');
+
+      const stack = d3.stack().keys(keys)(data);
+
+      const x = d3
+         .scaleBand()
+         .domain(data.map((d) => d.name))
+         .range([0, innerWidth])
+         .padding(0.2);
+
+      const y = d3
+         .scaleLinear()
+         .domain([0, d3.max(stack.flat(), (d) => d[1])])
+         .range([innerHeight, 0]);
+
+      const g = svg.append('g').attr('transform', `translate(${margin.left}, ${margin.top})`);
+
+      const tooltip = d3
+         .select('body')
+         .append('div')
+         .style('position', 'absolute')
+         .style('visibility', 'hidden')
+         .style('background', 'rgba(0, 0, 0, 0.8)')
+         .style('color', 'white')
+         .style('padding', '8px')
+         .style('border-radius', '5px')
+         .style('font-size', '26px')
+         .style('pointer-events', 'none');
+
+      g.selectAll('g')
+         .data(stack)
+         .enter()
+         .append('g')
+         .attr('fill', (d) => colors[d.key])
+         .selectAll('rect')
+         .data((d) => d)
+         .enter()
+         .append('rect')
+         .attr('x', (d) => x(d.data.name))
+         .attr('y', (d) => y(d[1]))
+         .attr('height', (d) => y(d[0]) - y(d[1]))
+         .attr('width', x.bandwidth())
+         .on('mouseover', (event, d) => {
+            tooltip
+               .style('visibility', 'visible')
+               .text(
+                  `카테고리: ${d.data.name}, 사이즈: ${
+                     d3.select(event.target.parentNode).datum().key
+                  }, 재고: ${d[1] - d[0]}`,
+               )
+               .style('left', `${event.pageX + 10}px`)
+               .style('top', `${event.pageY - 20}px`);
+         })
+         .on('mousemove', (event) => {
+            tooltip.style('left', `${event.pageX + 10}px`).style('top', `${event.pageY - 20}px`);
+         })
+         .on('mouseout', () => {
+            tooltip.style('visibility', 'hidden');
+         });
+
+      g.append('g')
+         .attr('transform', `translate(0, ${innerHeight})`)
+         .call(d3.axisBottom(x).tickSize(5).tickPadding(10))
+         .selectAll('text')
+         .attr('transform', 'rotate(-20)')
+         .style('text-anchor', 'end')
+         .style('font-size', '18px');
+
+      g.append('g').call(d3.axisLeft(y)).selectAll('text').style('font-size', '20px');
+
+      const legend = svg.append('g').attr('transform', `translate(${innerWidth + margin.left + 10}, 50)`);
+      keys.forEach((key, i) => {
+         legend
+            .append('rect')
+            .attr('x', 0)
+            .attr('y', i * 20)
+            .attr('width', 16)
+            .attr('height', 16)
+            .attr('fill', colors[key]);
+
+         legend
+            .append('text')
+            .attr('x', 20)
+            .attr('y', i * 20 + 10)
+            .attr('font-size', '18px')
+            .text(key);
+      });
+   };
+
+   // 상품 활성 상태
+   const drawPieChart = () => {
+      const activeCount = productListForStats.filter((p) => p.status === 'active').length;
+      const disactiveCount = productListForStats.filter((p) => p.status === 'disactive').length;
+      const data = [
+         { name: 'Active', value: activeCount },
+         { name: 'Disactive', value: disactiveCount },
+      ];
+
+      d3.select(pieChartRef.current).selectAll('*').remove();
+
+      const width = pieChartRef.current.clientWidth;
+      const height = pieChartRef.current.clientHeight;
+      const radius = Math.min(width, height) / 2 - 20;
+
+      const svg = d3.select(pieChartRef.current).append('svg').attr('width', width).attr('height', height);
+
+      svg.append('text')
+         .attr('x', 20)
+         .attr('y', 40)
+         .attr('text-anchor', 'start')
+         .attr('class', 'chart-title')
+         .style('font-size', '22px')
+         .style('font-weight', 'bold')
+         .text('상품 활성 상태');
+
+      const g = svg.append('g').attr('transform', `translate(${width / 2}, ${height / 2})`);
+
+      const pie = d3.pie().value((d) => d.value)(data);
+      const arc = d3.arc().innerRadius(0).outerRadius(radius);
+      const colors = ['#0088FE', '#FF8042'];
+
+      const tooltip = d3
+         .select('body')
+         .append('div')
+         .style('position', 'absolute')
+         .style('visibility', 'hidden')
+         .style('background', 'rgba(0, 0, 0, 0.8)')
+         .style('color', 'white')
+         .style('padding', '8px')
+         .style('border-radius', '5px')
+         .style('font-size', '26px')
+         .style('pointer-events', 'none');
+
+      g.selectAll('path')
+         .data(pie)
+         .enter()
+         .append('path')
+         .attr('d', arc)
+         .attr('fill', (d, i) => colors[i])
+         .on('mouseover', (event, d) => {
+            tooltip
+               .style('visibility', 'visible')
+               .text(`${d.data.name}: ${d.data.value}`)
+               .style('left', `${event.pageX + 10}px`)
+               .style('top', `${event.pageY - 20}px`);
+         })
+         .on('mousemove', (event) => {
+            tooltip.style('left', `${event.pageX + 10}px`).style('top', `${event.pageY - 20}px`);
+         })
+         .on('mouseout', () => {
+            tooltip.style('visibility', 'hidden');
+         });
+   };
+
+   if (loading) {
+      return <Spinner />;
+   }
+
+   return (
+      <div className='chart-container'>
+         <div className='chart-box' ref={barChartRef}></div>
+         <div className='chart-box' ref={histogramRef}></div>
+         <div className='chart-box' ref={stackedBarChartRef}></div>
+         <div className='chart-box' ref={pieChartRef}></div>
+      </div>
+   );
+};
+
+export default AdminProductStats;

--- a/src/page/AdminProductPage/style/adminProduct.style.css
+++ b/src/page/AdminProductPage/style/adminProduct.style.css
@@ -1,50 +1,89 @@
-.card-area{
-    margin-top:20px;
+.card-area {
+   margin-top: 20px;
 }
-.admin-product-card{
-    border:1px solid red;
-
+.admin-product-card {
+   border: 1px solid red;
 }
-.tag{
-    margin-left:10px
-}
-
-.display-flex{
-    display:flex;
-    align-items: center;
-}
-.locate-center{
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    width: 100%;
-}
-.stock{
-    margin-right: 10px;
+.tag {
+   margin-left: 10px;
 }
 
-
-.mt-2{
-    margin-top: 20px;
+.display-flex {
+   display: flex;
+   align-items: center;
+}
+.locate-center {
+   display: flex;
+   flex-direction: column;
+   align-items: center;
+   width: 100%;
+}
+.stock {
+   margin-right: 10px;
 }
 
-.form-container{
-    padding:20px
-}
-.mr-1{
-    margin-right: 10px;
+.mt-2 {
+   margin-top: 20px;
 }
 
-.upload-image{
-    max-width: 458px;
-    width:100%
+.form-container {
+   padding: 20px;
 }
-.display-center{
-    display: flex;
-    justify-content: center;
+.mr-1 {
+   margin-right: 10px;
 }
-.error-message{
-    color: red;
-    font-size: 10pt;
-    padding-right: 10px;
+
+.upload-image {
+   max-width: 458px;
+   width: 100%;
+}
+.display-center {
+   display: flex;
+   justify-content: center;
+}
+.error-message {
+   color: red;
+   font-size: 10pt;
+   padding-right: 10px;
+}
+
+.chart-container {
+   display: flex;
+   justify-content: space-around;
+   align-items: center;
+   flex-wrap: wrap;
+   width: 100%;
+   padding: 20px;
+}
+
+.chart-container {
+   display: grid;
+   grid-template-columns: repeat(2, 1fr); /* 2열 그리드 */
+   grid-template-rows: repeat(2, 1fr); /* 2행 그리드 */
+   gap: 20px; /* 그리드 간 간격 */
+   width: 100%;
+   height: 100vh; /* 화면을 가득 채우도록 설정 */
+   padding: 20px;
+   box-sizing: border-box;
+}
+
+.chart-box {
+   width: 100%;
+   height: 100%;
+   border: 1px solid #ddd;
+   background-color: #fff;
+   box-shadow: 2px 2px 5px rgba(0, 0, 0, 0.1);
+   display: flex;
+   flex-direction: column;
+   justify-content: center;
+   align-items: center;
+   padding: 20px;
+   box-sizing: border-box;
+}
+
+.chart-title {
+   font-size: 18px;
+   font-weight: bold;
+   margin-bottom: 10px;
+   text-align: center;
 }

--- a/src/routes/AppRouter.js
+++ b/src/routes/AppRouter.js
@@ -1,36 +1,38 @@
-import React from "react";
-import { Route, Routes } from "react-router";
-import AdminOrderPage from "../page/AdminOrderPage/AdminOrderPage";
-import AdminProduct from "../page/AdminProductPage/AdminProductPage";
-import CartPage from "../page/CartPage/CartPage";
-import Login from "../page/LoginPage/LoginPage";
-import MyPage from "../page/MyPage/MyPage";
-import OrderCompletePage from "../page/OrderCompletePage/OrderCompletePage";
-import PaymentPage from "../page/PaymentPage/PaymentPage";
-import ProductAll from "../page/LandingPage/LandingPage";
-import ProductDetail from "../page/ProductDetailPage/ProductDetailPage";
-import RegisterPage from "../page/RegisterPage/RegisterPage";
-import PrivateRoute from "./PrivateRoute";
+import React from 'react';
+import { Route, Routes } from 'react-router';
+import AdminOrderPage from '../page/AdminOrderPage/AdminOrderPage';
+import AdminProduct from '../page/AdminProductPage/AdminProductPage';
+import CartPage from '../page/CartPage/CartPage';
+import Login from '../page/LoginPage/LoginPage';
+import MyPage from '../page/MyPage/MyPage';
+import OrderCompletePage from '../page/OrderCompletePage/OrderCompletePage';
+import PaymentPage from '../page/PaymentPage/PaymentPage';
+import ProductAll from '../page/LandingPage/LandingPage';
+import ProductDetail from '../page/ProductDetailPage/ProductDetailPage';
+import RegisterPage from '../page/RegisterPage/RegisterPage';
+import PrivateRoute from './PrivateRoute';
+import AdminProductStats from '../page/AdminProductPage/AdminProductStatsPage';
 
 const AppRouter = () => {
-  return (
-    <Routes>
-      <Route path="/" element={<ProductAll />} />
-      <Route path="/login" element={<Login />} />
-      <Route path="/register" element={<RegisterPage />} />
-      <Route path="/product/:id" element={<ProductDetail />} />
-      <Route element={<PrivateRoute permissionLevel="customer" />}>
-        <Route path="/cart" element={<CartPage />} />
-        <Route path="/payment" element={<PaymentPage />} />
-        <Route path="/payment/success" element={<OrderCompletePage />} />
-        <Route path="/account/purchase" element={<MyPage />} />
-      </Route>
-      <Route element={<PrivateRoute permissionLevel="admin" />}>
-        <Route path="/admin/product" element={<AdminProduct />} />
-        <Route path="/admin/order" element={<AdminOrderPage />} />
-      </Route>
-    </Routes>
-  );
+   return (
+      <Routes>
+         <Route path='/' element={<ProductAll />} />
+         <Route path='/login' element={<Login />} />
+         <Route path='/register' element={<RegisterPage />} />
+         <Route path='/product/:id' element={<ProductDetail />} />
+         <Route element={<PrivateRoute permissionLevel='customer' />}>
+            <Route path='/cart' element={<CartPage />} />
+            <Route path='/payment' element={<PaymentPage />} />
+            <Route path='/payment/success' element={<OrderCompletePage />} />
+            <Route path='/account/purchase' element={<MyPage />} />
+         </Route>
+         <Route element={<PrivateRoute permissionLevel='admin' />}>
+            <Route path='/admin/product' element={<AdminProduct />} />
+            <Route path='/admin/order' element={<AdminOrderPage />} />
+            <Route path='/admin/product/stats' element={<AdminProductStats />} />
+         </Route>
+      </Routes>
+   );
 };
 
 export default AppRouter;


### PR DESCRIPTION
### PR 종류

-  [ ] 🐞 Bugfix
-  [x] ✨ New Feature
-  [ ] 📚 Documentation
-  [ ] ♻️ Refactoring
-  [ ] 🧪 Other

### 핵심 내용

- 상품 통계 페이지에서 D3.js를 활용한 차트 시각화 기능을 추가
- 카테고리별 상품 개수, 가격 분포, 재고 상태, 활성 상태를 차트로 표시

### 부가 설명

- 막대 그래프 (Bar Chart)

  - 상품의 카테고리별 개수를 시각화
  - X축 카테고리명, Y축 상품 개수
  - 툴팁 기능 추가 및 X축 레이블이 잘리지 않도록 회전 적용
   ![image](https://github.com/user-attachments/assets/b733d9a7-d8e8-434c-8fd4-3209fcc8ebb2)


- 히스토그램 (Histogram)

  - 상품 가격 분포를 보여주는 차트
  - 가격 구간을 10개 bin으로 나누어 상품 개수를 표시
  - 툴팁 기능 추가 및 X축 레이블 회전 조정
   ![image](https://github.com/user-attachments/assets/28b10e68-0143-4fea-a620-2e5504762c6b)


- 스택형 막대 그래프 (Stacked Bar Chart)

  - 카테고리별 사이즈별 재고를 시각화
  - M, L, XL, XXL 각 사이즈별 색상 지정
  - 범례를 우측 상단에 배치하여 X축과 겹치지 않도록 수정
   ![image](https://github.com/user-attachments/assets/0ada9967-b936-4eae-a044-4486285634b7)


- 파이 차트 (Pie Chart)

  - 상품 활성 상태 비율을 시각화
  - 활성(Active), 비활성(Disactive) 상품 개수를 비율로 표현
  - 차트 타이틀을 왼쪽 정렬 & 크기 조정
   ![image](https://github.com/user-attachments/assets/07a5c936-1a78-4cb3-a0ab-f9bf7c317c2d)
